### PR TITLE
[make] error: ‘transform’ is not a member of ‘std’

### DIFF
--- a/include/log2plot/config_manager.h
+++ b/include/log2plot/config_manager.h
@@ -5,6 +5,7 @@
 #include <yaml-cpp/parser.h>
 #include <fstream>
 #include <iostream>
+#include <algorithm>
 
 #include <log2plot/dir_tools.h>
 #include <log2plot/defines.h>


### PR DESCRIPTION
[MAKE ERROR]
config_manager.h:130:10: error: ‘transform’ is not a member of ‘std’ 
130 |     std::transform(vstr.begin(), vstr.end(),

[SOLVED]
<algorithm> header of the Standard library included in order to use the std::transform() function.